### PR TITLE
[SRVC-17749] Improve Gem Version & Info Merge to combine based on Digest

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,31 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.3.8, 2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.6, 3.1.4, 3.2.2]
+        ruby-version: [3.2.2]
         gem-version: [3.3.15]
-        include:
-          - ruby-version: 2.3.8
-            gem-version: 2.7.11
-          - ruby-version: 2.4.10
-            gem-version: 2.7.11
-          - ruby-version: 2.5.9
-            gem-version: 2.7.11
-          # Test with RubyGems 2.5.0 as it is specified in gemspec
-          - ruby-version: 2.3.8
-            gem-version: 2.5.0
-            continue-on-error: true
-          - ruby-version: 2.4.10
-            gem-version: 2.5.0
-            continue-on-error: true
-          - ruby-version: 2.5.9
-            gem-version: 2.5.0
-            continue-on-error: true
-          - ruby-version: 2.6.10
-            gem-version: 2.5.0
-            continue-on-error: true
-          - ruby-version: 2.7.8
-            gem-version: 2.5.0
-            continue-on-error: true
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,11 +1,8 @@
 name: Ruby
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
-
+    types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -54,7 +54,5 @@ jobs:
         ruby-version: 3.2.2
     - name: Run RuboCop
       run: |
-        bundle add rubocop --version 1.31.0
-        bundle add rubocop-minitest --version 0.20.1
-        bundle add rubocop-rake --version 0.6.0
+        bundle install --jobs 4 --retry 3
         bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ source "https://rubygems.org"
 gemspec
 group :development do
   gem 'byebug'
+  gem 'rubocop', '~> 1.31.0'
+  gem 'rubocop-minitest', '~> 0.20.1'
+  gem 'rubocop-rake', '~> 0.6.0'
 end
 group :test do
   gem 'minitest'

--- a/lib/geminabox/compact_index_api.rb
+++ b/lib/geminabox/compact_index_api.rb
@@ -34,12 +34,15 @@ module Geminabox
     def versions
       return local_versions unless Geminabox.rubygems_proxy
 
-      GemVersionsMerge.merge(local_versions, remote_versions)
+      GemVersionsMerge.new(local_versions, remote_versions).call
     end
 
     def info(name)
       if Geminabox.rubygems_proxy
-        local_gem_info(name) || remote_gem_info(name)
+        (
+          local_gem_info(name)&.lines.to_a +
+          remote_gem_info(name)&.lines.to_a
+        ).compact.sort.uniq.join
       else
         local_gem_info(name)
       end

--- a/lib/geminabox/compact_index_api.rb
+++ b/lib/geminabox/compact_index_api.rb
@@ -34,7 +34,7 @@ module Geminabox
     def versions
       return local_versions unless Geminabox.rubygems_proxy
 
-      GemVersionsMerge.new(local_versions, remote_versions).call
+      GemVersionsMerge.merge(local_versions, remote_versions)
     end
 
     def info(name)

--- a/lib/geminabox/compact_indexer.rb
+++ b/lib/geminabox/compact_indexer.rb
@@ -155,8 +155,8 @@ module Geminabox
       }
       say title unless progressbar_options
 
-      fork_type = {in_processes: n}
-      fork_type = {in_threads: n} if RUBY_PLATFORM == 'x64-mingw32'
+      fork_type = { in_processes: n }
+      fork_type = { in_threads: n } if RUBY_PLATFORM == 'x64-mingw32'
 
       infos = Parallel.map(specs, progress: progressbar_options, **fork_type) do |name, versions|
         info = dependency_info(versions)

--- a/lib/geminabox/disk_cache.rb
+++ b/lib/geminabox/disk_cache.rb
@@ -85,7 +85,14 @@ module Geminabox
     end
 
     def write_int(key_hash)
-      File.open(path(key_hash), 'wb') { |f| yield(f) }
+      File.open(path(key_hash), 'wb') { |f| yield(f) }.then { @retried = false }
+    rescue Errno::ENOENT => e
+      raise e if @retried
+
+      # There is a possibility that the directory is removed by another process.
+      ensure_dir_exists!
+      @retried = true
+      retry
     end
 
   end

--- a/lib/geminabox/gem_versions_merge.rb
+++ b/lib/geminabox/gem_versions_merge.rb
@@ -66,10 +66,6 @@ module Geminabox
       Time.parse(preamble[0].split[1])
     end
 
-    def datadir
-      Geminabox.data
-    end
-
     def combine_gems!(source)
       return if source.empty?
 

--- a/lib/geminabox/gem_versions_merge.rb
+++ b/lib/geminabox/gem_versions_merge.rb
@@ -10,6 +10,10 @@ module Geminabox
       @remote_gem_list = remote_gem_list
     end
 
+    def self.merge(local_gem_list, remote_gem_list)
+      new(local_gem_list, remote_gem_list).call
+    end
+
     def call
       return local_gem_list unless remote_gem_list
 

--- a/lib/geminabox/parallel_spec_reader.rb
+++ b/lib/geminabox/parallel_spec_reader.rb
@@ -17,8 +17,8 @@ module Geminabox
         }
         say title unless progressbar_options
 
-        fork_type = {in_processes: n}
-        fork_type = {in_threads: n} if RUBY_PLATFORM == 'x64-mingw32'
+        fork_type = { in_processes: n }
+        fork_type = { in_threads: n } if RUBY_PLATFORM == 'x64-mingw32'
         Parallel.map(gems, progress: progressbar_options, **fork_type) do |gemfile|
           map_gem_file_to_spec(gemfile)
         end.compact

--- a/test/units/geminabox/compact_index_api_test.rb
+++ b/test/units/geminabox/compact_index_api_test.rb
@@ -133,7 +133,8 @@ module Geminabox
     def test_local_info_takes_precedence_when_configured
       Geminabox.rubygems_proxy = true
       reindex
-
+      remote_info = "--\n1.0.0 |checksum:whatever\n"
+      @remote_api.expect(:fetch_info, [304, remote_info], ["b", nil])
       local_info = @api.info("b")
       assert_match(/---\n1.0.0 |checksum:\S{64}/, local_info)
     end
@@ -144,7 +145,7 @@ module Geminabox
 
       @remote_api.expect(:fetch_versions, [200, conflicting_remote_versions], [nil])
       versions = @api.versions
-      assert_match(/\Acreated_at:.+\n---\na 2.0.0 \S{32}\nb 1.0.0 \S{32}\nz 1.0.0 \S{32}\n\z/, versions)
+      assert_match(/\Acreated_at:.+\n---\na 2.0.0 \S{32}\nb 1.0.0 \S{32}\nz 1.0.0 \S{32}\nz 2.0.0 \S{32}\n\z/, versions)
       @remote_api.verify
     end
 

--- a/test/units/geminabox/gem_versions_merge_test.rb
+++ b/test/units/geminabox/gem_versions_merge_test.rb
@@ -3,41 +3,76 @@ require_relative '../../test_helper'
 module Geminabox
   class GemVersionsMergeTest < Minitest::Test
 
+    def setup
+      clean_data_dir
+    end
+
     def test_merge_local_over_remote
       local = "created_at: 2021-07-27T16:14:36.466+0000\n---\ntest-gem 0.0.1 91643f56b430feed3f6725c91fcfac70\n"
-      remote = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem 0.0.5 e7218e76477e2137355d2e7ded094925\n"
-      expected = local
-      assert_equal expected, GemVersionsMerge.merge(local, remote)
+      remote = "created_at: 2021-06-27T16:14:36.466+0000\n---\n" \
+               "test-gem 0.0.5 e7218e76477e2137355d2e7ded094925\n"
+      expected = "created_at: 2021-07-27T16:14:36.466+0000\n---\n" \
+                 "test-gem 0.0.1 91643f56b430feed3f6725c91fcfac70\n" \
+                 "test-gem 0.0.5 e7218e76477e2137355d2e7ded094925\n"
+      assert_equal expected, GemVersionsMerge.new(local, remote).call
     end
 
     def test_timestamp_local_over_remote
       local = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem 0.0.1 91643f56b430feed3f6725c91fcfac70\n"
       remote = "created_at: 2020-06-27T16:14:36.466+0000\n---\ntest-gem 0.0.5 e7218e76477e2137355d2e7ded094925\n"
       expected = local[/created_at:\s(\S+)\s/]
-      timestamp = GemVersionsMerge.merge(local, remote)[/created_at:\s(\S+)\s/]
+      timestamp = GemVersionsMerge.new(local, remote).call[/created_at:\s(\S+)\s/]
       assert_equal expected, timestamp
     end
 
     def test_merge_multiple_local_over_remote
       local = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70\ntest-gem2 0.0.1 75f21fffe3703239725b848bf82d3143\n"
       remote = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem2 0.0.2 c379eb80dd9b53e8b99e5507c8aebcb0\ntest-gem3 0.0.1 4e58bc03e301f704950410b713c20b69\ntest-gem4 0.0.1 e00c558565f7b03a438fbd93d854b7de\n"
-      merged = GemVersionsMerge.merge(local, remote)
+      merged = GemVersionsMerge.new(local, remote).call
       expected = "created_at: 2021-06-27T16:14:36.466+0000\n---\n" \
                  "test-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70\n" \
                  "test-gem2 0.0.1 75f21fffe3703239725b848bf82d3143\n" \
+                 "test-gem2 0.0.2 c379eb80dd9b53e8b99e5507c8aebcb0\n" \
                  "test-gem3 0.0.1 4e58bc03e301f704950410b713c20b69\n" \
                  "test-gem4 0.0.1 e00c558565f7b03a438fbd93d854b7de\n"
       assert_equal expected, merged
     end
 
     def test_merge_multiple_remote_version_entries_are_merged
+      local = <<~LOCAL
+        created_at: 2021-06-27T16:14:36.466+0000
+        ---
+        test-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70
+        test-gem2 0.0.1 75f21fffe3703239725b848bf82d3143
+      LOCAL
+      remote = <<~REMOTE
+        created_at: 2021-06-27T16:14:36.466+0000
+        ---
+        test-gem3 0.0.1,0.0.2 c379eb80dd9b53e8b99e5507c8aebcb0
+        test-gem3 1.0.0 4e58bc03e301f704950410b713c20b69
+      REMOTE
+
+      merged = GemVersionsMerge.new(local, remote).call
+      expected = <<~EXPECTED
+        created_at: 2021-06-27T16:14:36.466+0000
+        ---
+        test-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70
+        test-gem2 0.0.1 75f21fffe3703239725b848bf82d3143
+        test-gem3 0.0.1,0.0.2 c379eb80dd9b53e8b99e5507c8aebcb0
+        test-gem3 1.0.0 4e58bc03e301f704950410b713c20b69
+      EXPECTED
+
+      assert_equal expected, merged
+    end
+
+    def test_merge_multiple_removes_verions_with_same_name_different_digests
       local = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70\ntest-gem2 0.0.1 75f21fffe3703239725b848bf82d3143\n"
-      remote = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem3 0.0.1,0.0.2 c379eb80dd9b53e8b99e5507c8aebcb0\ntest-gem3 1.0.0 4e58bc03e301f704950410b713c20b69\n"
-      merged = GemVersionsMerge.merge(local, remote)
+      remote = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70\ntest-gem1 0.0.1 75f21fffe3703239725b848bf82d3143\n"
+      merged = GemVersionsMerge.new(local, remote).call
       expected = "created_at: 2021-06-27T16:14:36.466+0000\n---\n" \
+                 "test-gem1 0.0.1 75f21fffe3703239725b848bf82d3143\n" \
                  "test-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70\n" \
-                 "test-gem2 0.0.1 75f21fffe3703239725b848bf82d3143\n" \
-                 "test-gem3 0.0.1,0.0.2,1.0.0 4e58bc03e301f704950410b713c20b69\n"
+                 "test-gem2 0.0.1 75f21fffe3703239725b848bf82d3143\n"
       assert_equal expected, merged
     end
 

--- a/test/units/geminabox/gem_versions_merge_test.rb
+++ b/test/units/geminabox/gem_versions_merge_test.rb
@@ -14,21 +14,21 @@ module Geminabox
       expected = "created_at: 2021-07-27T16:14:36.466+0000\n---\n" \
                  "test-gem 0.0.1 91643f56b430feed3f6725c91fcfac70\n" \
                  "test-gem 0.0.5 e7218e76477e2137355d2e7ded094925\n"
-      assert_equal expected, GemVersionsMerge.new(local, remote).call
+      assert_equal expected, GemVersionsMerge.merge(local, remote)
     end
 
     def test_timestamp_local_over_remote
       local = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem 0.0.1 91643f56b430feed3f6725c91fcfac70\n"
       remote = "created_at: 2020-06-27T16:14:36.466+0000\n---\ntest-gem 0.0.5 e7218e76477e2137355d2e7ded094925\n"
       expected = local[/created_at:\s(\S+)\s/]
-      timestamp = GemVersionsMerge.new(local, remote).call[/created_at:\s(\S+)\s/]
+      timestamp = GemVersionsMerge.merge(local, remote)[/created_at:\s(\S+)\s/]
       assert_equal expected, timestamp
     end
 
     def test_merge_multiple_local_over_remote
       local = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70\ntest-gem2 0.0.1 75f21fffe3703239725b848bf82d3143\n"
       remote = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem2 0.0.2 c379eb80dd9b53e8b99e5507c8aebcb0\ntest-gem3 0.0.1 4e58bc03e301f704950410b713c20b69\ntest-gem4 0.0.1 e00c558565f7b03a438fbd93d854b7de\n"
-      merged = GemVersionsMerge.new(local, remote).call
+      merged = GemVersionsMerge.merge(local, remote)
       expected = "created_at: 2021-06-27T16:14:36.466+0000\n---\n" \
                  "test-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70\n" \
                  "test-gem2 0.0.1 75f21fffe3703239725b848bf82d3143\n" \
@@ -52,7 +52,7 @@ module Geminabox
         test-gem3 1.0.0 4e58bc03e301f704950410b713c20b69
       REMOTE
 
-      merged = GemVersionsMerge.new(local, remote).call
+      merged = GemVersionsMerge.merge(local, remote)
       expected = <<~EXPECTED
         created_at: 2021-06-27T16:14:36.466+0000
         ---
@@ -68,7 +68,7 @@ module Geminabox
     def test_merge_multiple_removes_verions_with_same_name_different_digests
       local = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70\ntest-gem2 0.0.1 75f21fffe3703239725b848bf82d3143\n"
       remote = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70\ntest-gem1 0.0.1 75f21fffe3703239725b848bf82d3143\n"
-      merged = GemVersionsMerge.new(local, remote).call
+      merged = GemVersionsMerge.merge(local, remote)
       expected = "created_at: 2021-06-27T16:14:36.466+0000\n---\n" \
                  "test-gem1 0.0.1 75f21fffe3703239725b848bf82d3143\n" \
                  "test-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70\n" \


### PR DESCRIPTION
#### Error or Issue

```
bundle update ddtrace
Fetching gem metadata from http://localhost:9292/.....
Resolving dependencies...
Could not find compatible versions

Because ddtrace >= 1.12.0 depends on libddwaf ~> 1.9.0.0.0
  and libddwaf ~> 1.9.0.0.0 could not be found in rubygems repository http://localhost:9292/ or installed locally for any resolution platforms (ruby),
  ddtrace >= 1.12.0 cannot be used.
So, because Gemfile depends on ddtrace >= 1.12,
  version solving has failed.

The source contains the following gems matching 'libddwaf (~> 1.9.0.0.0)':
  * libddwaf-1.9.0.0.0-arm64-darwin
  * libddwaf-1.9.0.0.0-x86_64-darwin

```

#### Testing

```
rakeup
```

Gemfile
```ruby
source "http://localhost:9292"


group :development do
  gem 'byebug'
  gem 'rubocop', '~> 1.31.0'
  gem 'rubocop-minitest', '~> 0.20.1'
  gem 'rubocop-rake', '~> 0.6.0'
end
group :test do
  gem 'minitest'
  gem 'minitest-reporters'
  gem 'rack-test'
  gem 'rake'

  gem 'capybara-mechanize'
  # Pin capybara to 3.36.x or earlier as 3.37.x does not work with Ruby 2.7/3.0/3.1
  # see https://github.com/teamcapybara/capybara/pull/2546
  gem 'capybara', '< 3.37.0'

  gem 'webmock'

  # Used only in test/requests/atom_feed_test.rb
  gem "rss", require: false

  gem "simplecov"
end

```

```
bundle install
```

🍺 